### PR TITLE
A few fixes

### DIFF
--- a/Sources/SCWaveformCache.m
+++ b/Sources/SCWaveformCache.m
@@ -135,7 +135,7 @@ static float SCDecibelAverage(double sample, NSUInteger sampleCount) {
     timeRange.duration = CMTimeConvertScale(timeRange.duration, sampleRate, kCMTimeRoundingMethod_Default);
     UInt64 totalSamples = timeRange.duration.value;
     
-    NSUInteger samplesPerPixel = totalSamples / width;
+    NSUInteger samplesPerPixel = roundf((CGFloat)totalSamples / (CGFloat)width);
     samplesPerPixel = samplesPerPixel < 1 ? 1 : samplesPerPixel;
     
     CMTimeRange oldTimeRange = timeRange;

--- a/Sources/SCWaveformCache.m
+++ b/Sources/SCWaveformCache.m
@@ -113,7 +113,7 @@ static float SCDecibelAverage(double sample, NSUInteger sampleCount) {
     
     AVAssetTrack *songTrack = [audioTrackArray objectAtIndex:0];
     
-    UInt32 channelCount;
+    UInt32 channelCount = 1;
     NSArray *formatDesc = songTrack.formatDescriptions;
     UInt32 sampleRate = 0;
     for (NSUInteger i = 0; i < [formatDesc count]; ++i) {

--- a/Sources/SCWaveformCache.m
+++ b/Sources/SCWaveformCache.m
@@ -393,7 +393,7 @@ static float SCDecibelAverage(double sample, NSUInteger sampleCount) {
         }
 
 #if SCWaveformDebug
-        NSLog(@"Read timeRange %fs to %fs. New cache duration: %fs (end bounds: %fs), asset duration :%fs", CMTimeGetSeconds(timeRange.start), CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration)),
+        NSLog(@"Read timeRange %fs to %fs. New cache duration: %fs (end bounds: %fs), asset duration: %fs", CMTimeGetSeconds(timeRange.start), CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration)),
               CMTimeGetSeconds([self cacheDuration]), CMTimeGetSeconds(CMTimeAdd(_cachedStartTime, [self cacheDuration])), CMTimeGetSeconds([self actualAssetDuration]));
 #endif
     }

--- a/Sources/SCWaveformCache.m
+++ b/Sources/SCWaveformCache.m
@@ -44,7 +44,7 @@
     _cachedStartTime = kCMTimeInvalid;
     _channelsCachedData = [NSMutableArray new];
     
-    for (int i = 0; i < _maxChannels; i++) {
+    for (NSUInteger i = 0; i < _maxChannels; i++) {
         [_channelsCachedData addObject:[NSMutableData new]];
     }
     _readEndOfAsset = NO;
@@ -116,7 +116,7 @@ static float SCDecibelAverage(double sample, NSUInteger sampleCount) {
     UInt32 channelCount;
     NSArray *formatDesc = songTrack.formatDescriptions;
     UInt32 sampleRate = 0;
-    for (unsigned int i = 0; i < [formatDesc count]; ++i) {
+    for (NSUInteger i = 0; i < [formatDesc count]; ++i) {
         CMAudioFormatDescriptionRef item = (__bridge CMAudioFormatDescriptionRef)[formatDesc objectAtIndex:i];
         const AudioStreamBasicDescription* fmtDesc = CMAudioFormatDescriptionGetStreamBasicDescription(item);
         
@@ -234,7 +234,7 @@ static float SCDecibelAverage(double sample, NSUInteger sampleCount) {
         NSUInteger addedSampleCount = 0;
         NSMutableArray *channelsData = [NSMutableArray new];
         
-        for (int i = 0; i < channelCount; i++) {
+        for (NSUInteger i = 0; i < channelCount; i++) {
             [channelsData addObject:[NSMutableData new]];
         }
         
@@ -279,7 +279,7 @@ static float SCDecibelAverage(double sample, NSUInteger sampleCount) {
                 int currentChannel = 0;
                 Float32 sample = 0;
                 
-                for (int i = 0; i < sampleCount; i++) {
+                for (NSUInteger i = 0; i < sampleCount; i++) {
                     sample = *samples;
                     
                     BOOL isLastChannel = currentChannel + 1 == channelCount;
@@ -338,7 +338,7 @@ static float SCDecibelAverage(double sample, NSUInteger sampleCount) {
         }
         
         if (addedSampleCount != 0 && isLastSegment) {
-            for (int i = 0; i < channelCount; i++) {
+            for (NSUInteger i = 0; i < channelCount; i++) {
                 float averageSample = SCDecibelAverage(addedSamples[i], addedSampleCount);
                 NSMutableData *data = [channelsData objectAtIndex:i];
 
@@ -356,7 +356,7 @@ static float SCDecibelAverage(double sample, NSUInteger sampleCount) {
         }
 #endif
         
-        for (int i = 0; i < channelCount; i++) {
+        for (NSUInteger i = 0; i < channelCount; i++) {
             NSMutableData *data = [channelsData objectAtIndex:i];
             NSMutableData *cachedData = [_channelsCachedData objectAtIndex:i];
             

--- a/Sources/SCWaveformCache.m
+++ b/Sources/SCWaveformCache.m
@@ -156,7 +156,6 @@ static float SCDecibelAverage(double sample, NSUInteger sampleCount) {
     if (samplesPerPixel != _samplesPerPixel ||
         CMTIME_COMPARE_INLINE(CMTimeAdd(timeRange.start, timeRange.duration), <, _cachedStartTime) || CMTIME_COMPARE_INLINE(timeRange.start, >, cacheEndTime)) {
         [self invalidate];
-        cacheDuration = kCMTimeZero;
         cacheEndTime = kCMTimeInvalid;
     }
     


### PR DESCRIPTION
- Put logging behind a flag that is easier to turn on
- Used unsigned types, when possible
- Ran the analyzer, and fixed the warnings it generated
- Used `roundf` to make sure we predictable rounded the sample count.